### PR TITLE
Add Http Interface Client Registration via each group

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ repositories {
 }
 
 extra["springModulithVersion"] = "2.0.0-M3"
+extra["okHttpMockwebserver3"] = "5.1.0"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
@@ -45,6 +46,7 @@ dependencies {
     runtimeOnly("com.h2database:h2")
     // runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.squareup.okhttp3:mockwebserver3:${property("okHttpMockwebserver3")}")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/java/com/jiandong/core/http/HttpCaller.java
+++ b/src/main/java/com/jiandong/core/http/HttpCaller.java
@@ -1,0 +1,71 @@
+package com.jiandong.core.http;
+
+import java.util.List;
+
+import com.jiandong.core.http.apicontract.github.IssueService;
+import com.jiandong.core.http.apicontract.github.MilestoneService;
+import com.jiandong.core.http.apicontract.github.ReleaseService;
+import com.jiandong.core.http.apicontract.github.RepositoryService;
+import com.jiandong.core.http.apicontract.github.resp.Issue;
+import com.jiandong.core.http.apicontract.github.resp.Milestone;
+import com.jiandong.core.http.apicontract.github.resp.Release;
+import com.jiandong.core.http.apicontract.github.resp.Repository;
+import com.jiandong.core.http.apicontract.stackoverflow.Container;
+import com.jiandong.core.http.apicontract.stackoverflow.Question;
+import com.jiandong.core.http.apicontract.stackoverflow.QuestionService;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * A http interface client test component
+ */
+@Component
+public class HttpCaller {
+
+	private static final Logger log = LoggerFactory.getLogger(HttpCaller.class);
+
+	private final RepositoryService repositoryService;
+
+	private final IssueService issueService;
+
+	private final MilestoneService milestoneService;
+
+	private final ReleaseService releaseService;
+
+	private final QuestionService questionService;
+
+	@Value("${github.org:mjd507}")
+	private String org;
+
+	@Value("${github.repo:spring-unknown}")
+	private String repo;
+
+	public HttpCaller(RepositoryService repositoryService, IssueService issueService, MilestoneService milestoneService, ReleaseService releaseService, QuestionService questionService) {
+		this.repositoryService = repositoryService;
+		this.issueService = issueService;
+		this.milestoneService = milestoneService;
+		this.releaseService = releaseService;
+		this.questionService = questionService;
+	}
+
+	public Result call() {
+		Repository repository = repositoryService.getRepository(org, repo);
+		List<Milestone> milestones = milestoneService.getMilestones(org, repo);
+		List<Issue> issues = issueService.getOpenIssuesForMilestone(org, repo, milestones.get(0).number());
+		List<Release> releases = releaseService.getRecentReleases(org, repo);
+		Container<@NonNull Question> container = questionService.questions(repo, "votes");
+		Result result = new Result(repository, milestones, issues, releases, container);
+		log.info(result.toString());
+		return result;
+	}
+
+	public record Result(Repository repository, List<Milestone> milestones, List<Issue> issues,
+						 List<Release> releases, Container<@NonNull Question> questions) {
+
+	}
+
+}

--- a/src/main/java/com/jiandong/core/http/HttpServiceConfig.java
+++ b/src/main/java/com/jiandong/core/http/HttpServiceConfig.java
@@ -1,0 +1,40 @@
+package com.jiandong.core.http;
+
+import com.jiandong.core.http.apicontract.stackoverflow.QuestionService;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.support.RestClientHttpServiceGroupConfigurer;
+import org.springframework.web.service.registry.ImportHttpServices;
+
+@ImportHttpServices(
+		group = HttpServiceConfig.GROUP_GITHUB,
+		basePackages = {"com.jiandong.core.http.apicontract.github"}
+)
+@ImportHttpServices(group = HttpServiceConfig.GROUP_STACKOVERFLOW,
+		types = {QuestionService.class}
+)
+@Configuration
+public class HttpServiceConfig {
+
+	public static final String GROUP_GITHUB = "github";
+
+	public static final String GROUP_STACKOVERFLOW = "stackoverflow";
+
+	@Bean
+	RestClientHttpServiceGroupConfigurer groupConfigurer() {
+
+		return groups -> {
+			groups.filterByName(GROUP_GITHUB)
+					.forEachClient((group, builder) -> builder
+							.baseUrl("https://api.github.com")
+							.defaultHeader("Accept", "application/vnd.github.v3+json"));
+
+			groups.filterByName(GROUP_STACKOVERFLOW)
+					.forEachClient((group, builder) -> builder
+							.baseUrl("https://api.stackexchange.com?site=stackoverflow"));
+		};
+
+	}
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/github/IssueService.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/github/IssueService.java
@@ -1,0 +1,30 @@
+package com.jiandong.core.http.apicontract.github;
+
+import java.util.List;
+
+import com.jiandong.core.http.apicontract.github.req.State;
+import com.jiandong.core.http.apicontract.github.resp.Assignee;
+import com.jiandong.core.http.apicontract.github.resp.Issue;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.nullsLast;
+
+@HttpExchange("/repos/{org}/{repo}/issues")
+public interface IssueService {
+
+	@GetExchange
+	List<Issue> getIssuesForMilestone(@PathVariable String org, @PathVariable String repo,
+			@RequestParam int milestone, @RequestParam State state);
+
+	default List<Issue> getOpenIssuesForMilestone(String org, String repo, int milestone) {
+		List<Issue> issues = getIssuesForMilestone(org, repo, milestone, State.open);
+		issues.sort(comparing(Issue::assignee, nullsLast(comparing(Assignee::login))));
+		return issues;
+	}
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/github/MilestoneService.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/github/MilestoneService.java
@@ -1,0 +1,15 @@
+package com.jiandong.core.http.apicontract.github;
+
+import java.util.List;
+
+import com.jiandong.core.http.apicontract.github.resp.Milestone;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.service.annotation.GetExchange;
+
+public interface MilestoneService {
+
+	@GetExchange("/repos/{org}/{repo}/milestones")
+	List<Milestone> getMilestones(@PathVariable String org, @PathVariable String repo);
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/github/ReleaseService.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/github/ReleaseService.java
@@ -1,0 +1,22 @@
+package com.jiandong.core.http.apicontract.github;
+
+import java.util.List;
+
+import com.jiandong.core.http.apicontract.github.resp.Release;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+@HttpExchange("/repos/{org}/{repo}/releases")
+public interface ReleaseService {
+
+	@GetExchange
+	List<Release> getReleases(@PathVariable String org, @PathVariable String repo);
+
+	default List<Release> getRecentReleases(String org, String repo) {
+		List<Release> releases = getReleases(org, repo);
+		return releases.stream().filter(Release::isRecent).toList();
+	}
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/github/RepositoryService.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/github/RepositoryService.java
@@ -1,0 +1,15 @@
+package com.jiandong.core.http.apicontract.github;
+
+import com.jiandong.core.http.apicontract.github.resp.Repository;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+@HttpExchange("/repos/{org}")
+public interface RepositoryService {
+
+	@GetExchange("/{repo}")
+	Repository getRepository(@PathVariable String org, @PathVariable String repo);
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/github/package-info.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/github/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package com.jiandong.core.http.apicontract.github;

--- a/src/main/java/com/jiandong/core/http/apicontract/github/req/State.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/github/req/State.java
@@ -1,0 +1,5 @@
+package com.jiandong.core.http.apicontract.github.req;
+
+public enum State {
+	open, closed, all
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/github/resp/Assignee.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/github/resp/Assignee.java
@@ -1,0 +1,5 @@
+package com.jiandong.core.http.apicontract.github.resp;
+
+public record Assignee(String login) {
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/github/resp/Issue.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/github/resp/Issue.java
@@ -1,0 +1,12 @@
+package com.jiandong.core.http.apicontract.github.resp;
+
+import org.jspecify.annotations.Nullable;
+
+public record Issue(String id, int number, String title, @Nullable Assignee assignee) {
+
+	public String toString() {
+		return "#" + number + " \"" + title + "\", " +
+				(assignee != null ? "assigned to " + assignee.login() : "not assigned");
+	}
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/github/resp/Milestone.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/github/resp/Milestone.java
@@ -1,0 +1,27 @@
+package com.jiandong.core.http.apicontract.github.resp;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.jspecify.annotations.Nullable;
+
+public record Milestone(int number, String title, int open_issues, int closed_issues, @Nullable ZonedDateTime due_on)
+		implements Comparable<Milestone> {
+
+	public boolean hasDueDate() {
+		return (this.due_on != null);
+	}
+
+	@Override
+	public int compareTo(Milestone other) {
+		return other.title.compareTo(title);
+	}
+
+	@Override
+	public String toString() {
+		return "Milestone " + title + ", " +
+				"opened " + open_issues + ", closed " + closed_issues +
+				(hasDueDate() ? ", due on " + due_on.format(DateTimeFormatter.ISO_LOCAL_DATE) : "");
+	}
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/github/resp/Release.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/github/resp/Release.java
@@ -1,0 +1,16 @@
+package com.jiandong.core.http.apicontract.github.resp;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public record Release(String tag_name, ZonedDateTime created_at) {
+
+	public boolean isRecent() {
+		return created_at().plusMonths(2).isAfter(ZonedDateTime.now());
+	}
+
+	public String toString() {
+		return "[" + created_at.format(DateTimeFormatter.ISO_LOCAL_DATE) + "] release " + tag_name;
+	}
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/github/resp/Repository.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/github/resp/Repository.java
@@ -1,0 +1,14 @@
+package com.jiandong.core.http.apicontract.github.resp;
+
+import java.text.DecimalFormat;
+
+public record Repository(String name, int stargazers_count, int forks_count, int watchers_count) {
+
+	public String toString() {
+		return "Project " + name() + ": " +
+				DecimalFormat.getInstance().format(stargazers_count) + " stars, " +
+				DecimalFormat.getInstance().format(forks_count) + " forks, " +
+				DecimalFormat.getInstance().format(watchers_count) + " watchers";
+	}
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/github/resp/package-info.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/github/resp/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package com.jiandong.core.http.apicontract.github.resp;

--- a/src/main/java/com/jiandong/core/http/apicontract/stackoverflow/Container.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/stackoverflow/Container.java
@@ -1,0 +1,7 @@
+package com.jiandong.core.http.apicontract.stackoverflow;
+
+import java.util.List;
+
+public record Container<T>(List<T> items) {
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/stackoverflow/Question.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/stackoverflow/Question.java
@@ -1,0 +1,11 @@
+package com.jiandong.core.http.apicontract.stackoverflow;
+
+import org.springframework.web.util.HtmlUtils;
+
+public record Question(String title) {
+
+	public String toString() {
+		return "\"" + HtmlUtils.htmlUnescape(title) + "\"";
+	}
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/stackoverflow/QuestionService.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/stackoverflow/QuestionService.java
@@ -1,0 +1,13 @@
+package com.jiandong.core.http.apicontract.stackoverflow;
+
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+@HttpExchange("/questions")
+public interface QuestionService {
+
+	@GetExchange
+	Container<Question> questions(@RequestParam String tagged, @RequestParam String sort);
+
+}

--- a/src/main/java/com/jiandong/core/http/apicontract/stackoverflow/package-info.java
+++ b/src/main/java/com/jiandong/core/http/apicontract/stackoverflow/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package com.jiandong.core.http.apicontract.stackoverflow;

--- a/src/test/java/com/jiandong/core/http/HttpInterfaceClientTest.java
+++ b/src/test/java/com/jiandong/core/http/HttpInterfaceClientTest.java
@@ -1,0 +1,162 @@
+package com.jiandong.core.http;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import com.jiandong.core.http.apicontract.github.IssueService;
+import com.jiandong.core.http.apicontract.github.MilestoneService;
+import com.jiandong.core.http.apicontract.github.ReleaseService;
+import com.jiandong.core.http.apicontract.github.RepositoryService;
+import com.jiandong.core.http.apicontract.github.resp.Assignee;
+import com.jiandong.core.http.apicontract.github.resp.Issue;
+import com.jiandong.core.http.apicontract.github.resp.Milestone;
+import com.jiandong.core.http.apicontract.github.resp.Release;
+import com.jiandong.core.http.apicontract.github.resp.Repository;
+import com.jiandong.core.http.apicontract.stackoverflow.Container;
+import com.jiandong.core.http.apicontract.stackoverflow.Question;
+import com.jiandong.core.http.apicontract.stackoverflow.QuestionService;
+import mockwebserver3.Dispatcher;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+class HttpInterfaceClientTest {
+
+	private static final Logger log = LoggerFactory.getLogger(HttpInterfaceClientTest.class);
+
+	private final JsonMapper jsonMapper = new JsonMapper();
+
+	private final String org = "mjd507";
+
+	private final String repo = "spring-unknown";
+
+	private final Dispatcher dispatcher = new Dispatcher() {
+
+		@Override
+		public @NonNull MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+
+			return switch (request.getUrl().encodedPath()) {
+				case "/repos/" + org + "/" + repo -> {
+					var repository = new Repository("mock-spring-unknow", 1, 1, 2);
+					yield new MockResponse.Builder()
+							.addHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+							.body(jsonMapper.writeValueAsString(repository))
+							.build();
+				}
+				case "/repos/" + org + "/" + repo + "/milestones" -> {
+					Milestone milestone = new Milestone(11, "mock-milestone", 1, 1, ZonedDateTime.now().plusDays(2));
+					yield new MockResponse.Builder()
+							.addHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+							.body(jsonMapper.writeValueAsString(List.of(milestone)))
+							.build();
+				}
+				case "/repos/" + org + "/" + repo + "/issues" -> {
+					Issue issue = new Issue("1", 1, "mock-issue", new Assignee("mock-assignee"));
+					yield new MockResponse.Builder()
+							.addHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+							.body(jsonMapper.writeValueAsString(List.of(issue)))
+							.build();
+				}
+				case "/repos/" + org + "/" + repo + "/releases" -> {
+					Release release = new Release("mock-tag", ZonedDateTime.now().plusDays(20));
+					yield new MockResponse.Builder()
+							.addHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+							.body(jsonMapper.writeValueAsString(List.of(release)))
+							.build();
+				}
+				case "/questions" -> {
+					Container<@NonNull Question> container = new Container<>(List.of(new Question("mock-question")));
+					yield new MockResponse.Builder()
+							.addHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+							.body(jsonMapper.writeValueAsString(container))
+							.build();
+				}
+				default -> new MockResponse.Builder()
+						.code(404)
+						.build();
+			};
+		}
+	};
+
+	private MockWebServer githubServer;
+
+	private MockWebServer stackOverFlowServer;
+
+	@BeforeEach
+	void startServer() throws IOException {
+		this.githubServer = new MockWebServer();
+		this.githubServer.start();
+		this.githubServer.setDispatcher(dispatcher);
+
+		this.stackOverFlowServer = new MockWebServer();
+		this.stackOverFlowServer.start();
+		this.stackOverFlowServer.setDispatcher(dispatcher);
+	}
+
+	@AfterEach
+	void shutdown() {
+		if (this.githubServer != null) {
+			this.githubServer.close();
+		}
+		if (this.stackOverFlowServer != null) {
+			this.stackOverFlowServer.close();
+		}
+	}
+
+	@Test
+	void httpInterfaceClient() {
+		// use the HttpServiceProxyFactory to generate the http interface client.
+		// which uses the specified RestClient.
+		// and the RestClient are bind to the mock server.
+		RestClient githubRestClient = RestClient.builder()
+				.baseUrl(this.githubServer.url("/").toString())
+				.defaultHeader("Accept", "application/json")
+				.configureMessageConverters(clientBuilder -> clientBuilder
+						.registerDefaults()
+						.jsonMessageConverter(new JacksonJsonHttpMessageConverter(jsonMapper)))
+				.build();
+		HttpServiceProxyFactory githubHttpServiceFactory = HttpServiceProxyFactory
+				.builderFor(RestClientAdapter.create(githubRestClient)).build();
+		RepositoryService repositoryService = githubHttpServiceFactory.createClient(RepositoryService.class);
+		IssueService issueService = githubHttpServiceFactory.createClient(IssueService.class);
+		MilestoneService milestoneService = githubHttpServiceFactory.createClient(MilestoneService.class);
+		ReleaseService releaseService = githubHttpServiceFactory.createClient(ReleaseService.class);
+
+		RestClient stackOverFlowRestClient = RestClient.builder()
+				.baseUrl(this.stackOverFlowServer.url("/").toString())
+				.configureMessageConverters(clientBuilder -> clientBuilder
+						.registerDefaults()
+						.jsonMessageConverter(new JacksonJsonHttpMessageConverter(jsonMapper)))
+				.build();
+		HttpServiceProxyFactory stackOverFlowServiceFactory = HttpServiceProxyFactory
+				.builderFor(RestClientAdapter.create(stackOverFlowRestClient)).build();
+		QuestionService questionService = stackOverFlowServiceFactory.createClient(QuestionService.class);
+
+		HttpCaller httpCaller = new HttpCaller(repositoryService, issueService, milestoneService, releaseService, questionService);
+		ReflectionTestUtils.setField(httpCaller, "org", org);
+		ReflectionTestUtils.setField(httpCaller, "repo", repo);
+		HttpCaller.Result result = httpCaller.call();
+		Assertions.assertEquals("mock-spring-unknow", result.repository().name());
+		Assertions.assertEquals("mock-issue", result.issues().get(0).title());
+		Assertions.assertEquals("mock-milestone", result.milestones().get(0).title());
+		Assertions.assertEquals("mock-tag", result.releases().get(0).tag_name());
+		Assertions.assertEquals("mock-question", result.questions().items().get(0).title());
+	}
+
+}


### PR DESCRIPTION
since Spring 6.x, define an HTTP service through a Java interface with @HttpExchange are native supported.(like OpenFeign)

however, when many http interface client exists, setup can be quite repetitive and hard to organize.

spring 7.x add a http registry layer, to declare and configure many clients at once .

the code are all copied from : https://github.com/rstoyanchev/springio25-service-registry.  Thanks Rossen Stoyanchev

Add okhttp Mock Web Server -  Full Integration test.

more see:

https://spring.io/blog/2025/09/23/http-service-client-enhancements

https://spring.io/blog/2025/09/30/the-state-of-http-clients-in-spring