### PR TITLE
Add Programmatic way of Bean Registration via `BeanRegistrar`.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ extra["springModulithVersion"] = "2.0.0-M3"
 extra["okHttpMockwebserver3"] = "5.1.0"
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-h2console")
@@ -57,5 +57,8 @@ dependencyManagement {
 }
 
 tasks.withType<Test> {
+
+    testLogging.showStandardStreams = true
+
     useJUnitPlatform()
 }

--- a/src/main/java/com/jiandong/core/beanregistrar/BeanRegistrarConfig.java
+++ b/src/main/java/com/jiandong/core/beanregistrar/BeanRegistrarConfig.java
@@ -1,0 +1,43 @@
+package com.jiandong.core.beanregistrar;
+
+import org.springframework.beans.factory.BeanRegistrar;
+import org.springframework.beans.factory.BeanRegistry;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
+
+@Configuration
+@Import(BeanRegistrarConfig.DynamicBeanRegistrar.class)
+public class BeanRegistrarConfig {
+
+	static class DynamicBeanRegistrar implements BeanRegistrar {
+
+		@Override
+		public void register(BeanRegistry registry, Environment env) {
+			registry.registerBean(Foo.class);
+			registry.registerBean("bar", Bar.class, spec -> spec
+					.prototype()
+					.lazyInit()
+					.description("Custom description")
+					.supplier(context -> new Bar(context.bean(Foo.class))));
+			if (env.matchesProfiles("baz")) {
+				registry.registerBean(Baz.class, spec -> spec
+						.supplier(context -> new Baz("Hello World!")));
+			}
+		}
+
+	}
+
+	record Foo() {
+
+	}
+
+	record Bar(Foo foo) {
+
+	}
+
+	record Baz(String text) {
+
+	}
+
+}

--- a/src/main/java/com/jiandong/core/beanregistrar/package-info.java
+++ b/src/main/java/com/jiandong/core/beanregistrar/package-info.java
@@ -1,0 +1,2 @@
+@org.jspecify.annotations.NullMarked
+package com.jiandong.core.beanregistrar;

--- a/src/test/java/com/jiandong/ApplicationTest.java
+++ b/src/test/java/com/jiandong/ApplicationTest.java
@@ -1,8 +1,10 @@
 package com.jiandong;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
 class ApplicationTest {
 
     String[] args() {
@@ -11,9 +13,8 @@ class ApplicationTest {
         };
     }
 
-	@Disabled // will make other jms integration tests fail. msgs sent to queue may consume by this thread.
     @Test
-    void testMain() {
-        Application.main(args());
+	void contextLoad() {
+
     }
 }

--- a/src/test/java/com/jiandong/core/beanregistrar/BeanRegistrarConfigTest.java
+++ b/src/test/java/com/jiandong/core/beanregistrar/BeanRegistrarConfigTest.java
@@ -1,0 +1,36 @@
+package com.jiandong.core.beanregistrar;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = {BeanRegistrarConfig.class})
+@ActiveProfiles("baz")
+class BeanRegistrarConfigTest {
+
+	@Autowired BeanRegistrarConfig.Foo foo;
+
+	@Autowired BeanRegistrarConfig.Bar bar;
+
+	@Autowired BeanRegistrarConfig.Baz baz;
+
+	@Autowired ApplicationContext applicationContext;
+
+	@Test
+	void test() {
+		BeanRegistrarConfig.Foo foo2 = applicationContext.getBean(BeanRegistrarConfig.Foo.class);
+		Assertions.assertThat(foo)
+				.isNotNull()
+				.isSameAs(foo2);
+		BeanRegistrarConfig.Bar bar2 = applicationContext.getBean(BeanRegistrarConfig.Bar.class);
+		Assertions.assertThat(bar)
+				.isNotNull()
+				.isNotSameAs(bar2);
+		Assertions.assertThat(baz).isNotNull();
+	}
+
+}


### PR DESCRIPTION
spring 7.x introduces `BeanRegistrar` interface that can be implemented to register beans in a flexible and efficient way.

enable display gradle build output logs

more see: https://docs.spring.io/spring-framework/reference/7.0/core/beans/java/programmatic-bean-registration.html