### PR TITLE
Add Api-Versioning Support.

### DIFF
--- a/src/main/java/com/jiandong/core/apiversioning/AccountController.java
+++ b/src/main/java/com/jiandong/core/apiversioning/AccountController.java
@@ -1,0 +1,26 @@
+package com.jiandong.core.apiversioning;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/accounts")
+public class AccountController {
+
+	@GetMapping(value = "/{id}", version = "1.0")
+	Account getAccount(@PathVariable String id) {
+		return new Account(id, "default");
+	}
+
+	@GetMapping(path = "/{id}", version = "1.1+")
+	Account getAccount1_1(@PathVariable String id) {
+		return new Account(id, "advanced");
+	}
+
+	public record Account(String id, String name) {
+
+	}
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ server:
   port: 8080
 
 spring:
+  mvc:
+    apiversion:
+      required: true
+      use:
+        header: X-API-Version
   threads:
     virtual:
       enabled: true

--- a/src/test/java/com/jiandong/core/apiversioning/AccountControllerTest.java
+++ b/src/test/java/com/jiandong/core/apiversioning/AccountControllerTest.java
@@ -1,0 +1,68 @@
+package com.jiandong.core.apiversioning;
+
+import com.jiandong.security.WebSecurityConfig;
+import com.jiandong.support.MockMvcDecorator;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcBuilderCustomizer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.ConfigurableMockMvcBuilder;
+import org.springframework.web.client.ApiVersionInserter;
+
+@SpringBootTest(classes = {AccountController.class, AccountControllerTest.MockMvcApiVersionConfig.class, WebSecurityConfig.class})
+@ImportAutoConfiguration({WebMvcAutoConfiguration.class})
+@AutoConfigureMockMvc
+class AccountControllerTest {
+
+	@Autowired MockMvcTester mockMvcTester;
+
+	@Test
+	void getAccount_400_no_apiVersion() {
+		MockMvcDecorator.normalUserGet(mockMvcTester)
+				.uri("/accounts/99")
+				.assertThat()
+				.hasStatus(HttpStatus.BAD_REQUEST)
+				.hasErrorMessage("API version is required.");
+	}
+
+	@Test
+	void getAccount_1_0_version_withDefaultName() {
+		MockMvcDecorator.normalUserGet(mockMvcTester)
+				.uri("/accounts/99")
+				.apiVersion(1.0)
+				.assertThat()
+				.hasStatusOk()
+				.bodyJson().isEqualTo("{\"id\":\"99\",\"name\":\"default\"}");
+	}
+
+	@Test
+	void getAccount_1_1_version_withAdvancedName() {
+		MockMvcDecorator.normalUserGet(mockMvcTester)
+				.uri("/accounts/99")
+				.apiVersion(1.1)
+				.assertThat()
+				.hasStatusOk()
+				.bodyJson().isEqualTo("{\"id\":\"99\",\"name\":\"advanced\"}");
+	}
+
+	@TestConfiguration
+	public static class MockMvcApiVersionConfig implements MockMvcBuilderCustomizer {
+
+		@Override
+		public void customize(ConfigurableMockMvcBuilder<?> builder) {
+			builder.apiVersionInserter(ApiVersionInserter.useHeader("X-API-Version"))
+					.alwaysDo(MockMvcResultHandlers.print());
+		}
+
+	}
+
+}
+

--- a/src/test/java/com/jiandong/security/WebSecurityTest.java
+++ b/src/test/java/com/jiandong/security/WebSecurityTest.java
@@ -1,6 +1,6 @@
 package com.jiandong.security;
 
-import org.junit.jupiter.api.Assertions;
+import com.jiandong.support.MockMvcDecorator;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,52 +9,50 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(classes = {
 		WebSecurityConfig.class,
 		WebSecurityTest.SecurityTestController.class,
 })
 @ImportAutoConfiguration({
-		DispatcherServletAutoConfiguration.class, MockMvcAutoConfiguration.class
+		MockMvcAutoConfiguration.class
 })
 public class WebSecurityTest {
 
 	private static final Logger log = LoggerFactory.getLogger(WebSecurityTest.class);
 
-	@Autowired MockMvc mockMvc;
+	@Autowired MockMvcTester mockMvcTester;
 
 	@Test
 	void test_200_no_authentication() throws Exception {
-		MvcResult mvcResult = mockMvc.perform(get("/public/security1"))
-				.andExpect(status().isOk())
-				.andReturn();
-		String response = mvcResult.getResponse().getContentAsString();
-		Assertions.assertEquals("public-content-allowed", response);
+		MockMvcDecorator.normalUserGet(mockMvcTester)
+				.uri("/public/security1")
+				.assertThat()
+				.hasStatusOk()
+				.bodyText()
+				.isEqualTo("public-content-allowed");
 	}
 
 	@Test
 	void test_401() throws Exception {
-		mockMvc.perform(get("/private/security2"))
-				.andExpect(status().isUnauthorized());
+		mockMvcTester.get()
+				.uri("/private/security2")
+				.assertThat()
+				.hasStatus(HttpStatus.UNAUTHORIZED);
 	}
 
 	@Test
 	void test_200_with_authentication() throws Exception {
-		MvcResult mvcResult = mockMvc.perform(get("/private/security2")
-						.header(HttpHeaders.AUTHORIZATION, "Basic dXNlcjp1c2VyX3B3ZA=="))
-				.andExpect(status().isOk())
-				.andReturn();
-		String response = mvcResult.getResponse().getContentAsString();
-		Assertions.assertEquals("allowed due to authentication success", response);
+		MockMvcDecorator.normalUserGet(mockMvcTester)
+				.uri("/private/security2")
+				.assertThat()
+				.hasStatusOk()
+				.bodyText()
+				.isEqualTo("allowed due to authentication success");
 	}
 
 	@RestController

--- a/src/test/java/com/jiandong/support/MockMvcDecorator.java
+++ b/src/test/java/com/jiandong/support/MockMvcDecorator.java
@@ -1,0 +1,29 @@
+package com.jiandong.support;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+
+public class MockMvcDecorator {
+
+	public static MockMvcTester.MockMvcRequestBuilder normalUserGet(MockMvcTester mockMvcTester) {
+		return normalUser(mockMvcTester, HttpMethod.GET);
+	}
+
+	public static MockMvcTester.MockMvcRequestBuilder normalUserPost(MockMvcTester mockMvcTester) {
+		return normalUser(mockMvcTester, HttpMethod.POST);
+	}
+
+	static MockMvcTester.MockMvcRequestBuilder normalUser(MockMvcTester mockMvcTester, HttpMethod httpMethod) {
+		return mockMvcTester
+				.method(httpMethod)
+				.header(HttpHeaders.AUTHORIZATION, "Basic dXNlcjp1c2VyX3B3ZA==");
+	}
+
+	static MockMvcTester.MockMvcRequestBuilder adminUser(MockMvcTester mockMvcTester, HttpMethod httpMethod) {
+		return mockMvcTester
+				.method(httpMethod)
+				.header(HttpHeaders.AUTHORIZATION, "Basic YWRtaW46YWRtaW5fcHdk==");
+	}
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  mvc:
+    apiversion:
+      required: true
+      use:
+        header: X-API-Version
   threads:
     virtual:
       enabled: true


### PR DESCRIPTION
spring 7.x start supporting api versioning. both server and client(RestClient/WebClient).

boot provides a convenient way to auto-configurer via few properties.

our application now force required api-version (with header `X-API-Version`) for each incoming request.

see `AccountControllerTest` to see how it works.

also replace `MockMvc` with `MockMvcTester` for test cases.

more see: https://spring.io/blog/2025/09/16/api-versioning-in-spring