### PR TITLE
Add Programmatic & Bean-Injection use of SpEL expression language.

### DIFF
--- a/src/main/java/com/jiandong/core/expression/Evaluator.java
+++ b/src/main/java/com/jiandong/core/expression/Evaluator.java
@@ -1,0 +1,37 @@
+package com.jiandong.core.expression;
+
+import java.time.LocalDateTime;
+
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+public class Evaluator {
+
+	SpelExpressionParser parser = new SpelExpressionParser();
+
+	// ===  basic evaluation cases === //
+
+	// 1. literal string.  "'Hello World'"  --- StringLiteral
+	// 2. method call.  "'Hello World'.concat('!')" --- StringLiteral/MethodReference
+	// 3. property/field call.
+	// 		"'Hello World'.bytes"   => invokes 'getBytes()'   --- StringLiteral/PropertyOrFieldReference
+	// 	    "'Hello World'.bytes.length" => invokes 'getBytes().length' --- StringLiteral/PropertyOrFieldReference/PropertyOrFieldReference
+	// 4. constructor call. "new String('hello world').toUpperCase()"  --- ConstructorReference/MethodReference
+	public <T> T evaluateAgainstStringLiteral(String str, Class<T> desiredResultType) {
+		Expression expression = parser.parseExpression(str);
+		return expression.getValue(desiredResultType);
+	}
+
+	// === the more common usage of SpEL is to provide an expression string
+	// that is evaluated against a specific object instance (call root object). === //
+
+	public <T> T evaluateAgainstInventor(Inventor inventor, String expressionString, Class<T> desiredResultType) {
+		Expression expression = parser.parseExpression(expressionString);
+		return expression.getValue(inventor, desiredResultType);
+	}
+
+	public record Inventor(String name, LocalDateTime birthday, String nationality) {
+
+	}
+
+}

--- a/src/main/java/com/jiandong/core/expression/EvaluatorComponent.java
+++ b/src/main/java/com/jiandong/core/expression/EvaluatorComponent.java
@@ -1,0 +1,24 @@
+package com.jiandong.core.expression;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EvaluatorComponent {
+
+	@Value("#{ systemProperties }") // systemProperties is a bean provided by framework.
+	public Map<String, ?> systemProperties;
+
+	@Value("#{ evaluatorSupportBean.randomNumber }") // evaluate value from another bean's property.
+	public int supportNumber;
+
+}
+
+@Component
+class EvaluatorSupportBean {
+
+	public int randomNumber = 123;
+
+}

--- a/src/test/java/com/jiandong/core/expression/EvaluatorComponentTest.java
+++ b/src/test/java/com/jiandong/core/expression/EvaluatorComponentTest.java
@@ -1,0 +1,25 @@
+package com.jiandong.core.expression;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(classes = {EvaluatorComponent.class, EvaluatorSupportBean.class})
+class EvaluatorComponentTest {
+
+	@Autowired EvaluatorComponent evaluatorComponent;
+
+	@Test
+	void testBeanPropertyEvaluation() {
+		Assertions.assertThat(evaluatorComponent.systemProperties)
+				.isNotEmpty()
+				.hasSizeGreaterThan(0)
+				.containsKeys("java.home", "user.country");
+
+		Assertions.assertThat(evaluatorComponent.supportNumber)
+				.isEqualTo(123);
+	}
+
+}

--- a/src/test/java/com/jiandong/core/expression/EvaluatorTest.java
+++ b/src/test/java/com/jiandong/core/expression/EvaluatorTest.java
@@ -1,0 +1,41 @@
+package com.jiandong.core.expression;
+
+import java.time.LocalDateTime;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class EvaluatorTest {
+
+	Evaluator evaluator = new Evaluator();
+
+	@Test
+	void testEvaluateAgainstStringLiteral() {
+		String literalString = evaluator.evaluateAgainstStringLiteral("'Hello World'", String.class);
+		Assertions.assertThat(literalString).isEqualTo("Hello World");
+
+		String methodReturnValue = evaluator.evaluateAgainstStringLiteral("'Hello World'.concat('!')", String.class);
+		Assertions.assertThat(methodReturnValue).isEqualTo("Hello World!");
+
+		byte[] propertyValue = evaluator.evaluateAgainstStringLiteral("'Hello World'.bytes", byte[].class);
+		Assertions.assertThat(propertyValue).isEqualTo("Hello World".getBytes());
+
+		int propertyValue2 = evaluator.evaluateAgainstStringLiteral("'Hello World'.bytes.length", int.class);
+		Assertions.assertThat(propertyValue2).isEqualTo("Hello World".length());
+
+		String constructorCall = evaluator.evaluateAgainstStringLiteral("new String('hello world').toUpperCase()", String.class);
+		Assertions.assertThat(constructorCall).isEqualTo("HELLO WORLD");
+
+	}
+
+	@Test
+	void testEvaluateAgainstInventor() {
+		Evaluator.Inventor inventor = new Evaluator.Inventor("Nikola Tesla", LocalDateTime.of(1856, 7, 9, 0, 0), "Serbian");
+		String name = evaluator.evaluateAgainstInventor(inventor, "name", String.class);
+		Assertions.assertThat(name).isEqualTo("Nikola Tesla");
+
+		Boolean nameMatched = evaluator.evaluateAgainstInventor(inventor, "name == 'Nikola Tesla'", boolean.class);
+		Assertions.assertThat(nameMatched).isTrue();
+	}
+
+}


### PR DESCRIPTION
SpEL was introduced in Spring 3.0 in Dec 2009, so many years!

This part I add an `Evaluator` class which is a programmatic way on how to use SpEL to parse expressions.

Also add an `EvaluatorComponent` bean, demonstrate in Spring container how we use SpEL to inject values.

There are much more SpEL powerful capabilities need further investigating.

core concept in SpEL is ast. (a new lesson for me :) )

more see:
https://docs.spring.io/spring-framework/reference/core/expressions.html

https://youtu.be/0uvQQuxyAv4