### PR TITLE
Tests are orderable & structure are force verified during build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation("io.micrometer:micrometer-tracing-bridge-brave")
     implementation("org.springframework.modulith:spring-modulith-events-jdbc") // event-publication table
     implementation("org.springframework.modulith:spring-modulith-starter-jdbc")
+    implementation("org.springframework.modulith:spring-modulith-core") // application modules check
     runtimeOnly("com.h2database:h2")
     // runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/test/java/com/jiandong/ApplicationModuleTest.java
+++ b/src/test/java/com/jiandong/ApplicationModuleTest.java
@@ -1,0 +1,18 @@
+package com.jiandong;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.modulith.core.ApplicationModules;
+
+@Order(1)
+class ApplicationModuleTest {
+
+	@Test
+	void verifyAppModules() {
+		ApplicationModules modules = ApplicationModules.of(Application.class);
+		modules.forEach(System.out::println);
+		modules.verify();
+	}
+
+}

--- a/src/test/java/com/jiandong/ApplicationTest.java
+++ b/src/test/java/com/jiandong/ApplicationTest.java
@@ -1,20 +1,17 @@
 package com.jiandong;
 
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.test.context.SpringBootTest;
-
-@SpringBootTest
+// make this test run at last.
+// due to shared middle-ware like mq are not clean.
+// (messages consumes here but verified in other test class)
+@Order(value = Integer.MAX_VALUE)
 class ApplicationTest {
 
-    String[] args() {
-        return new String[] {
-                "--spring.main.web-application-type=none"
-        };
-    }
-
-    @Test
+	@Test
 	void contextLoad() {
+		Application.main(new String[] {});
+	}
 
-    }
 }

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation


### PR DESCRIPTION
add a global property in `junit-platform.properties`, to tell junit run tests in a class based order.

Make ApplicationTest in last run, due to Application always hangs there, have no choice to dirty its context, which causes shared data race condition.

Also include `spring-modulith-core` to verify application module structure.

more see:

https://docs.spring.io/spring-modulith/reference/verification.html