### PR TITLE
include `ShedLock` distribute lock for scheduler tasks.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,11 +26,12 @@ repositories {
 
 extra["springModulithVersion"] = "2.0.0-M3"
 extra["okHttpMockwebserver3"] = "5.1.0"
+extra["shedlockVersion"] = "6.10.0"
 
 dependencies {
+    implementation("org.springframework:spring-aspects")
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-h2console")
     implementation("org.springframework.boot:spring-boot-starter-batch")
     implementation("org.springframework.boot:spring-boot-starter-security")
@@ -44,6 +45,8 @@ dependencies {
     implementation("org.springframework.modulith:spring-modulith-events-jdbc") // event-publication table
     implementation("org.springframework.modulith:spring-modulith-starter-jdbc")
     implementation("org.springframework.modulith:spring-modulith-core") // application modules check
+    implementation("net.javacrumbs.shedlock:shedlock-spring")
+    implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template")
     runtimeOnly("com.h2database:h2")
     // runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
@@ -54,6 +57,7 @@ dependencies {
 dependencyManagement {
     imports {
         mavenBom("org.springframework.modulith:spring-modulith-bom:${property("springModulithVersion")}")
+        mavenBom("net.javacrumbs.shedlock:shedlock-bom:${property("shedlockVersion")}")
     }
 }
 

--- a/src/main/java/com/jiandong/lock/ShedLockConfig.java
+++ b/src/main/java/com/jiandong/lock/ShedLockConfig.java
@@ -1,0 +1,27 @@
+package com.jiandong.lock;
+
+import javax.sql.DataSource;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "10s", defaultLockAtLeastFor = "2s")
+public class ShedLockConfig {
+
+	@Bean
+	public LockProvider jdbcLockProvider(DataSource dataSource) {
+		return new JdbcTemplateLockProvider(
+				JdbcTemplateLockProvider.Configuration.builder()
+						.withJdbcTemplate(new JdbcTemplate(dataSource))
+						.usingDbTime()
+						.build()
+		);
+	}
+
+}

--- a/src/main/java/com/jiandong/transactionaloutbox/modulith/EventScheduler.java
+++ b/src/main/java/com/jiandong/transactionaloutbox/modulith/EventScheduler.java
@@ -3,6 +3,8 @@ package com.jiandong.transactionaloutbox.modulith;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+
 import org.springframework.modulith.events.IncompleteEventPublications;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -16,7 +18,7 @@ public class EventScheduler {
 		this.incompleteEventPublications = incompleteEventPublications;
 	}
 
-	// need distribute lock in multi instances
+	@SchedulerLock(name = "Modulith-Event")
 	@Scheduled(initialDelay = 5, fixedDelay = 5, timeUnit = TimeUnit.MINUTES)
 	public void runNonCompletedEvent() {
 		incompleteEventPublications.resubmitIncompletePublicationsOlderThan(Duration.ofMinutes(3));

--- a/src/main/resources/schema/shedlock/schema-h2.sql
+++ b/src/main/resources/schema/shedlock/schema-h2.sql
@@ -1,0 +1,7 @@
+CREATE TABLE shedlock (
+	name VARCHAR(64) NOT NULL,
+	lock_until TIMESTAMP(3) NOT NULL,
+	locked_at TIMESTAMP(3) NOT NULL,
+	locked_by VARCHAR(255) NOT NULL,
+	PRIMARY KEY (name)
+);

--- a/src/test/java/com/jiandong/lock/ShedLockConfigTest.java
+++ b/src/test/java/com/jiandong/lock/ShedLockConfigTest.java
@@ -1,0 +1,30 @@
+package com.jiandong.lock;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// for usage test,
+// see EventSchedulerTest.testScheduler
+// and OutboxEventSchedulerTest.testScheduler
+@SpringBootTest(classes = {ShedLockConfig.class, DataSourceAutoConfiguration.class})
+class ShedLockConfigTest {
+
+	@Autowired
+	ShedLockConfig shedLockConfig;
+
+	@Autowired
+	LockProvider jdbcLockProvider;
+
+	@Test
+	void testConfig() {
+		assertThat(shedLockConfig).isNotNull();
+		assertThat(jdbcLockProvider).isNotNull();
+	}
+
+}

--- a/src/test/java/com/jiandong/transactionaloutbox/modulith/EventSchedulerTest.java
+++ b/src/test/java/com/jiandong/transactionaloutbox/modulith/EventSchedulerTest.java
@@ -1,0 +1,51 @@
+package com.jiandong.transactionaloutbox.modulith;
+
+import java.util.concurrent.CountDownLatch;
+
+import com.jiandong.lock.ShedLockConfig;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.modulith.events.IncompleteEventPublications;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest(classes = {EventScheduler.class, ShedLockConfig.class})
+@ImportAutoConfiguration({DataSourceAutoConfiguration.class})
+@DirtiesContext
+class EventSchedulerTest {
+
+	@Autowired EventScheduler eventScheduler;
+
+	@MockitoBean IncompleteEventPublications incompleteEventPublications;
+
+	@Sql(scripts = {"classpath:shedlock/schema-h2.sql"})
+	@Test
+	void testScheduler() throws InterruptedException {
+		doNothing().when(incompleteEventPublications).resubmitIncompletePublicationsOlderThan(any());
+		int threadCount = 5;
+		CountDownLatch latch = new CountDownLatch(threadCount);
+		for (int i = 0; i < threadCount; i++) {
+			Thread.ofVirtual().start(() -> {
+				try {
+					eventScheduler.runNonCompletedEvent();
+				}
+				finally {
+					latch.countDown();
+				}
+			});
+		}
+		latch.await();
+		verify(incompleteEventPublications, times(1)).resubmitIncompletePublicationsOlderThan(any());
+	}
+
+}

--- a/src/test/java/com/jiandong/transactionaloutbox/normal/OutboxEventSchedulerTest.java
+++ b/src/test/java/com/jiandong/transactionaloutbox/normal/OutboxEventSchedulerTest.java
@@ -1,0 +1,55 @@
+package com.jiandong.transactionaloutbox.normal;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import com.jiandong.lock.ShedLockConfig;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(classes = {OutboxEventScheduler.class, ShedLockConfig.class})
+@ImportAutoConfiguration({DataSourceAutoConfiguration.class})
+@DirtiesContext
+class OutboxEventSchedulerTest {
+
+	@Autowired
+	OutboxEventScheduler outboxEventScheduler;
+
+	@MockitoBean OutboxEventDao outboxEventDao;
+
+	@MockitoBean NotifyService3 notifyService3;
+
+	@Sql(scripts = {"classpath:shedlock/schema-h2.sql"})
+	@Test
+	void testScheduler() throws InterruptedException {
+		when(outboxEventDao.listNonCompletedEvents(any())).thenReturn(List.of(new OutboxEvent(1, "", "", null, null)));
+		int threadCount = 5;
+		CountDownLatch latch = new CountDownLatch(threadCount);
+		for (int i = 0; i < threadCount; i++) {
+			Thread.ofVirtual().start(() -> {
+				try {
+					outboxEventScheduler.runNonCompletedEvent();
+				}
+				finally {
+					latch.countDown();
+				}
+			});
+		}
+		latch.await();
+		verify(outboxEventDao, times(1)).listNonCompletedEvents(any());
+		verify(notifyService3, times(1)).sendNotification(any());
+	}
+
+}

--- a/src/test/resources/shedlock/schema-h2.sql
+++ b/src/test/resources/shedlock/schema-h2.sql
@@ -1,0 +1,9 @@
+DROP TABLE shedlock IF EXISTS;
+
+CREATE TABLE shedlock (
+	name VARCHAR(64) NOT NULL,
+	lock_until TIMESTAMP(3) NOT NULL,
+	locked_at TIMESTAMP(3) NOT NULL,
+	locked_by VARCHAR(255) NOT NULL,
+	PRIMARY KEY (name)
+);


### PR DESCRIPTION
use its `JdbcTemplateLockProvider`,

explicitly specify `defaultLockAtLeastFor` to '2s',  make sure the lock will be kept at least 2 seconds.  just in case the duration of the task is shorter than clock difference between nodes. which could cause task run more than once.

Also set `defaultLockAtMostFor` to '10s', so even JVM downs, other nodes can have chance in next turn.

more see:

https://github.com/lukas-krecan/ShedLock