### PR TITLE
Upgrade to Spring-Boot 4.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,9 @@
-import com.google.protobuf.gradle.id
-
 plugins {
     java
-    id("org.springframework.boot") version "4.0.6"
+    id("org.springframework.boot") version "4.1.0"
     id("io.spring.dependency-management") version "1.1.7"
     jacoco
-    id("com.google.protobuf") version "0.9.5"
+    id("com.google.protobuf") version "0.9.6"
 }
 
 group = "com.jiandong"
@@ -47,8 +45,7 @@ dependencies {
     implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template")
     implementation("org.postgresql:postgresql")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")
-    implementation("io.grpc:grpc-services")
-    implementation("org.springframework.grpc:spring-grpc-spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-starter-grpc-server")
     testImplementation("org.testcontainers:testcontainers-postgresql")
     testImplementation("org.testcontainers:testcontainers-activemq")
     testImplementation("org.testcontainers:testcontainers-junit-jupiter")
@@ -63,7 +60,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-websocket-test")
     testImplementation("org.springframework.modulith:spring-modulith-starter-test")
     testImplementation("com.squareup.okhttp3:mockwebserver3:5.4.0")
-    testImplementation("org.springframework.grpc:spring-grpc-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-grpc-client-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
@@ -71,7 +68,6 @@ dependencyManagement {
     imports {
         mavenBom("org.springframework.modulith:spring-modulith-bom:2.0.6")
         mavenBom("net.javacrumbs.shedlock:shedlock-bom:7.7.0")
-        mavenBom("org.springframework.grpc:spring-grpc-dependencies:1.0.3")
     }
 }
 
@@ -89,25 +85,5 @@ tasks.jacocoTestReport {
         xml.required = false
         csv.required = true
         html.required = false
-    }
-}
-
-protobuf {
-    protoc {
-        artifact = "com.google.protobuf:protoc"
-    }
-    plugins {
-        id("grpc") {
-            artifact = "io.grpc:protoc-gen-grpc-java"
-        }
-    }
-    generateProtoTasks {
-        all().forEach {
-            it.plugins {
-                id("grpc") {
-                    option("@generated=omit")
-                }
-            }
-        }
     }
 }

--- a/src/test/java/com/jiandong/grpc/GrpcServerServiceTest.java
+++ b/src/test/java/com/jiandong/grpc/GrpcServerServiceTest.java
@@ -9,20 +9,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration;
 import org.springframework.boot.grpc.server.autoconfigure.GrpcServerAutoConfiguration;
-import org.springframework.boot.grpc.test.autoconfigure.AutoConfigureInProcessTransport;
-import org.springframework.boot.grpc.test.autoconfigure.InProcessTestAutoConfiguration;
+import org.springframework.boot.grpc.test.autoconfigure.AutoConfigureTestGrpcTransport;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.grpc.client.ImportGrpcClients;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(classes = GrpcServerService.class)
-@AutoConfigureInProcessTransport
+@AutoConfigureTestGrpcTransport
 @ImportGrpcClients(basePackageClasses = HelloServiceGrpc.class)
 @ImportAutoConfiguration(classes = {
 		GrpcServerAutoConfiguration.class,
 		SslAutoConfiguration.class,
-		InProcessTestAutoConfiguration.class // allow channel to support all target, not just [in-process:]
 })
 class GrpcServerServiceTest {
 


### PR DESCRIPTION
more see:
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.1-Release-Notes

specifically for grpc migration, see:
https://github.com/spring-projects/spring-grpc/wiki/Spring-gRPC-1.1-Migration-Guide